### PR TITLE
Fix voice messages on Mattermost mobile clients

### DIFF
--- a/webapp/src/client/client.js
+++ b/webapp/src/client/client.js
@@ -79,6 +79,12 @@ export default class Client {
                     root_id: rootId,
                     message: 'Voice Message',
                     type: 'custom_voice',
+                    // file_ids is required so Mattermost mobile clients (which
+                    // don't load plugin webapp bundles and therefore never
+                    // render the registered `custom_voice` PostType) still get
+                    // a renderable MP3 attachment with their native inline
+                    // audio player.
+                    file_ids: [res.body.file_infos[0].id],
                     props: {
                         fileId: res.body.file_infos[0].id,
                         duration: recording.duration,

--- a/webapp/src/components/post_type/post_type.css
+++ b/webapp/src/components/post_type/post_type.css
@@ -21,3 +21,23 @@ button.voice-player-playbutton {
   border: none;
   outline: inherit;
 }
+
+/*
+ * `file_ids` is set on voice-message posts so Mattermost mobile clients can
+ * render the MP3 attachment (mobile doesn't load plugin webapp bundles so it
+ * never reaches our PostType component). On web the PostType already renders
+ * the audio inline, so the default file-attachment card would be a duplicate.
+ * Scope the hide to posts whose body contains our custom .voice-player so
+ * other file attachments in the channel are unaffected.
+ */
+.post__body:has(.voice-player) .post-image__column,
+.post__body:has(.voice-player) .post-image__columns,
+.post__body:has(.voice-player) [data-testid="fileAttachmentList"],
+.post:has(.voice-player) .post-image__column,
+.post:has(.voice-player) .post-image__columns,
+.post:has(.voice-player) [data-testid="fileAttachmentList"],
+[data-testid="postView"]:has(.voice-player) .post-image__column,
+[data-testid="postView"]:has(.voice-player) .post-image__columns,
+[data-testid="postView"]:has(.voice-player) [data-testid="fileAttachmentList"] {
+  display: none !important;
+}


### PR DESCRIPTION
## Problem

Voice messages created by this plugin are invisible / unplayable on Mattermost mobile clients (iOS and Android).

The plugin currently creates posts with:
- `type: "custom_voice"`
- `props.fileId: <fileId>` (the uploaded MP3)

But it does **not** set `file_ids` on the post.

Mobile clients don't load plugin webapp bundles, so they never reach the `PostType` component registered via `registry.registerPostTypeComponent('custom_voice', ...)`. They fall back to default post rendering — but with `file_ids` empty there's no attachment to display, so the post shows only the plain-text `"Voice Message"` body with no playable audio.

## After this PR

On Mattermost mobile (iOS, app v2.40.0), voice messages now render with the native inline audio player:

<img src="https://github.com/zainali89/mattermost-plugin-voice/raw/feat/redesign-player-ui/docs/voice-mobile.png" alt="Voice message on Mattermost mobile after the fix" width="320">

(no "before" screenshot — the bug is that nothing playable shows up at all, just the plain-text post body)

## Fix

Two small changes:

1. **`webapp/src/client/client.js`** — when creating the post, set `file_ids: [fileInfos[0].id]` alongside the existing `type` and `props.fileId`. Mobile clients render this through Mattermost's native inline audio player.

2. **`webapp/src/components/post_type/post_type.css`** — add a `:has()` rule that hides the default file-attachment card on web. On web, the plugin's `PostType` component already renders the audio inline, so the duplicate file card would be redundant.

   The hide is scoped (`:has(.voice-player)`) to posts that contain the custom player, so any other MP3 file in the channel is unaffected.

## Tested on

- Mattermost server 10.11.0
- Mattermost mobile app v2.40.0 (iOS) — voice messages now appear with the native inline audio player (screenshot above)
- Mattermost web (Chrome) — no visible change, still using the `PostType` audio player

## Backward compatibility / existing posts

For voice posts created before this patch, `post.file_ids` will still be empty in the database, so they will continue to render only via the custom PostType on web (and stay invisible on mobile). To backfill them so mobile users can play historical voice messages, run on the Postgres DB:

```sql
UPDATE posts SET fileids =
  '["' || (props->>'fileId') || '"]'
  WHERE type = 'custom_voice'
  AND fileids = '[]'
  AND props->>'fileId' IS NOT NULL;

UPDATE fileinfo fi SET postid = p.id
  FROM posts p
  WHERE p.type = 'custom_voice'
  AND fi.id = (p.props->>'fileId')
  AND fi.postid IS NULL;
```

## Related

- Issue #65 (Mattermost 10.x compatibility) — this PR addresses the mobile-rendering side.
- Companion PR #68 — redesigns the web `PostType` UI so it visually matches the mobile native player. Independent of this PR; either can land first.
